### PR TITLE
[RFC] Patch X server 1.19.3 to fix VGA arbitration overflow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,10 +12,14 @@ ALL_URLS := $(foreach pkg,$(PACKAGES_FROM_FC28), \
 					$(FC28_UPDATES_BASEURL), $(FC28_BASEURL))/$(shell echo $(pkg)|head -c 1|tr A-Z a-z)/$(pkg)) \
             $(foreach pkg,$(PACKAGES_FROM_FC25), \
 				$(if $(findstring $(pkg), $(PACKAGES_FROM_FC25_UPDATES)), \
+					$(FC25_UPDATES_BASEURL), $(FC25_BASEURL))/$(shell echo $(pkg)|head -c 1|tr A-Z a-z)/$(pkg)) \
+            $(foreach pkg,$(PACKAGES_FROM_FC25_NEED_PATCH), \
+				$(if $(findstring $(pkg), $(PACKAGES_FROM_FC25_UPDATES)), \
 					$(FC25_UPDATES_BASEURL), $(FC25_BASEURL))/$(shell echo $(pkg)|head -c 1|tr A-Z a-z)/$(pkg))
 
 ALL_ORIG_FILES := $(notdir $(ALL_URLS))
-ALL_FILES := $(ALL_ORIG_FILES:%.fc28.src.rpm=%.fc25.src.rpm)
+ALL_FILES := $(ALL_ORIG_FILES:%.fc28.src.rpm=%.fc25.src.rpm) \
+	     $(PACKAGES_FROM_FC25_NEED_PATCH:%.fc25.src.rpm=%.need-patch.fc25.src.rpm)
 
 ifneq ($(DISTFILES_MIRROR),)
 ALL_URLS := $(addprefix $(DISTFILES_MIRROR),$(ALL_FILES))

--- a/Makefile.builder
+++ b/Makefile.builder
@@ -13,7 +13,19 @@ PACKAGES_FROM_FC25 := \
   satyr-0.21-2.fc25.src.rpm \
   PackageKit-1.1.5-1.fc25.src.rpm \
   grub2-2.02-0.38.fc25.src.rpm \
-  systemtap-3.2-2.fc25.src.rpm
+  systemtap-3.2-2.fc25.src.rpm \
+
+# rebuild with Fedora 25 rpm, but with local patches
+# HACK: When we pass the list of rpms to the Qubes build script, we
+# append a "need-patch" suffix. Instructions for applying the patch
+# is written in the Makefile in a case-by-case basis.
+PACKAGES_FROM_FC25_NEED_PATCH := \
+  xorg-x11-server-1.19.3-1.fc25.src.rpm
+
+xorg-x11-server-1.19.3-1.need-patch.fc25.src.rpm:
+	mkdir xorg-x11-server-1.19.3-1.need-patch.fc25.src.rpm
+	rpm2cpio xorg-x11-server-1.19.3-1.fc25.src.rpm | cpio -ivd -D xorg-x11-server-1.19.3-1.need-patch.fc25.src.rpm
+	patch -d xorg-x11-server-1.19.3-1.need-patch.fc25.src.rpm -p1 < xorg-x11-server-1.19.3-1-fix-vga-arbitration-overflow.patch
 
 # used by Makefile, not relevant for RPM_SRC_PACKAGES
 PACKAGES_FROM_FC25_UPDATES := \
@@ -21,11 +33,14 @@ PACKAGES_FROM_FC25_UPDATES := \
   hawkey-0.6.4-3.fc25.src.rpm \
   PackageKit-1.1.5-1.fc25.src.rpm \
   grub2-2.02-0.38.fc25.src.rpm \
-  systemtap-3.2-2.fc25.src.rpm
+  systemtap-3.2-2.fc25.src.rpm \
+  xorg-x11-server-1.19.3-1.fc25.src.rpm
 
 ifeq ($(DIST), fc25)
     RPM_SRC_PACKAGES.dom0 := $(PACKAGES_FROM_FC28:%.fc28.src.rpm=%.$(DIST).src.rpm) \
                              $(PACKAGES_FROM_FC25)
+    RPM_SOURCE_DIR := $(DIST_SRC_ROOT)/$(COMPONENT)/xorg-x11-server-1.19.3-1.need-patch.fc25.src.rpm/
+    RPM_SPEC_FILES := xorg-x11-server-1.19.3-1.need-patch.fc25.src.rpm/xorg-x11-server.spec
 endif
 
 # Increase versions to force the update of rebuilt packages.

--- a/xorg-x11-server-1.19.3-1-fix-vga-arbitration-overflow.patch
+++ b/xorg-x11-server-1.19.3-1-fix-vga-arbitration-overflow.patch
@@ -1,0 +1,67 @@
+Binary files xorg-x11-server-1.19.3-1.need-patch.fc25.src.rpm/.swp and xorg-x11-server-1.19.3-1.need-patch.fc25.src.rpm.new/.swp differ
+diff -uprN xorg-x11-server-1.19.3-1.need-patch.fc25.src.rpm/fix-vga-arbitration.patch xorg-x11-server-1.19.3-1.need-patch.fc25.src.rpm.new/fix-vga-arbitration.patch
+--- xorg-x11-server-1.19.3-1.need-patch.fc25.src.rpm/fix-vga-arbitration.patch	1970-01-01 00:00:00.000000000 +0000
++++ xorg-x11-server-1.19.3-1.need-patch.fc25.src.rpm.new/fix-vga-arbitration.patch	2021-12-11 16:34:58.169000000 +0000
+@@ -0,0 +1,50 @@
++From cf7517675d988c2d1ff967d6d162a17acbdad466 Mon Sep 17 00:00:00 2001
++From: Keith Packard <keithp@keithp.com>
++Date: Wed, 2 Aug 2017 21:34:52 -0700
++Subject: [PATCH] xfree86: Hold input_lock across SPRITE functions in VGA
++ arbiter
++
++Avoid scrambling the sprite functions wrapper.
++
++Bugzilla: https://bugs.freedesktop.org/show_bug.cgi?id=101995
++Signed-off-by: Keith Packard <keithp@keithp.com>
++Reviewed-by: Adam Jackson <ajax@redhat.com>
++---
++ hw/xfree86/common/xf86VGAarbiterPriv.h | 20 +++++++++++++-------
++ 1 file changed, 13 insertions(+), 7 deletions(-)
++
++diff --git a/hw/xfree86/common/xf86VGAarbiterPriv.h b/hw/xfree86/common/xf86VGAarbiterPriv.h
++index 09be10aa3..03db55700 100644
++--- a/hw/xfree86/common/xf86VGAarbiterPriv.h
+++++ b/hw/xfree86/common/xf86VGAarbiterPriv.h
++@@ -73,14 +73,20 @@
++ 
++ #define UNWRAP_SCREEN_INFO(x) pScrn->x = pScreenPriv->x
++ 
++-#define SPRITE_PROLOG miPointerScreenPtr PointPriv = \
++-    (miPointerScreenPtr)dixLookupPrivate(&pScreen->devPrivates, \
++-    miPointerScreenKey); VGAarbiterScreenPtr pScreenPriv = \
++-    ((VGAarbiterScreenPtr)dixLookupPrivate(&(pScreen)->devPrivates, \
++-    VGAarbiterScreenKey)); PointPriv->spriteFuncs = pScreenPriv->miSprite;
+++#define SPRITE_PROLOG                                           \
+++    miPointerScreenPtr PointPriv;                               \
+++    VGAarbiterScreenPtr pScreenPriv;                            \
+++    input_lock();                                               \
+++    PointPriv = dixLookupPrivate(&pScreen->devPrivates,         \
+++                                 miPointerScreenKey);           \
+++    pScreenPriv = dixLookupPrivate(&(pScreen)->devPrivates,     \
+++                                   VGAarbiterScreenKey);        \
+++    PointPriv->spriteFuncs = pScreenPriv->miSprite;             \
++ 
++-#define SPRITE_EPILOG pScreenPriv->miSprite = PointPriv->spriteFuncs;\
++-    PointPriv->spriteFuncs  = &VGAarbiterSpriteFuncs;
+++#define SPRITE_EPILOG                                   \
+++    pScreenPriv->miSprite = PointPriv->spriteFuncs;     \
+++    PointPriv->spriteFuncs  = &VGAarbiterSpriteFuncs;   \
+++    input_unlock();
++ 
++ #define WRAP_SPRITE do { pScreenPriv->miSprite = PointPriv->spriteFuncs;\
++     	PointPriv->spriteFuncs  = &VGAarbiterSpriteFuncs; 		\
++-- 
++GitLab
++
+diff -uprN xorg-x11-server-1.19.3-1.need-patch.fc25.src.rpm/xorg-x11-server.spec xorg-x11-server-1.19.3-1.need-patch.fc25.src.rpm.new/xorg-x11-server.spec
+--- xorg-x11-server-1.19.3-1.need-patch.fc25.src.rpm/xorg-x11-server.spec	2021-12-11 16:29:25.200000000 +0000
++++ xorg-x11-server-1.19.3-1.need-patch.fc25.src.rpm.new/xorg-x11-server.spec	2021-12-11 16:34:37.467000000 +0000
+@@ -105,6 +105,8 @@ Patch7027: xserver-autobind-hotplug.patc
+ # because the display-managers are not ready yet, do not upstream
+ Patch10000: 0001-Fedora-hack-Make-the-suid-root-wrapper-always-start-.patch
+ 
++Patch20000: fix-vga-arbitration.patch
++
+ %global moduledir	%{_libdir}/xorg/modules
+ %global drimoduledir	%{_libdir}/dri
+ %global sdkdir		%{_includedir}/xorg


### PR DESCRIPTION
In https://github.com/QubesOS/qubes-issues/issues/7076, I reported a known VGA arbitration bug in xorg-server 1.19.3 causes the QubesOS X server to crash randomly when both an Intel & an extra GPU are installed on the system, regardless of whether the Intel GPU is used.

Because this bug crashes my desktop 30 times a day, I'm now trying to fix the issue by myself. and after spending a day on fighting with and abusing the QubesOS build system, I came up with the following hack.

It basically,

1. Add a new list called `PACKAGES_FROM_FC25_NEED_PATCH`, within this variable is a list of packages which we need to apply for a custom patch. Now only `xorg-x11-server-1.19.3-1.fc25.src.rpm` is listed.
2. But we can't use the existing file name, otherwise it would be added to `ALL_FILES` and triggers a RPM auto build, without a chance of applying the patch. Thus, I did a hack by renaming all packages in `PACKAGES_FROM_FC25_NEED_PATCH` from `*.fc25.src.rpm` to `.need-patch.fc25.src.rpm`
3. Because the `.need-patch` target doesn't exist, I can now trigger `make` to build to target using my rules. Thus, I then subsequently wrote a build rule for `xorg-x11-server-1.19.3-1.need-patch.fc25.src.rpm` for applying the patch. These build rules need to be written on a case-by-case basis, manually.
4. The rule for `xorg-x11-server-1.19.3-1.need-patch.fc25.src.rpm` unpacks `xorg-x11-server-1.19.3-1.need-patch.fc25.src.rpm` to the directory `xorg-x11-server-1.19.3-1.need-patch.fc25.src.rpm`, then apply a patch `xorg-x11-server-1.19.3-1-fix-vga-arbitration-overflow.patch`, which was created manually.
5. Finally, we add the RPM spec location to `RPM_SPEC_FILES`, and with the appropriate `RPM_SOURCE_DIR := $(DIST_SRC_ROOT)/$(COMPONENT)/xorg-x11-server-1.19.3-1.need-patch.fc25.src.rpm/`, and let the QubesOS build system to generate a patched RPM package.

As you see, I don't know much about Makefile or the QubesOS build system, and this fix uses a lot of hacks, especially, the files and paths in step 5 are hardcoded. Thus I don't think it's upstreamable in its current condition, nevertheless I think it's still a good idea to publish the patch in its half-finished form. 

I think what we need is a general solution for applying a custom patch to an arbitrary RPM package, once finished, the maintainer should be able to apply patches just by modifying a variable or two. 

I'd like to hear your suggestion on the proper way to extend the build script.